### PR TITLE
fix Expected isFloatingType error for pytorch version 1.2+

### DIFF
--- a/pointnet2/pointnet2_utils.py
+++ b/pointnet2/pointnet2_utils.py
@@ -68,7 +68,9 @@ class FurthestPointSampling(Function):
         torch.Tensor
             (B, npoint) tensor containing the set
         """
-        return _ext.furthest_point_sampling(xyz, npoint)
+        fps_inds = _ext.furthest_point_sampling(xyz, npoint)
+        ctx.mark_non_differentiable(fps_inds)
+        return fps_inds
 
     @staticmethod
     def backward(xyz, a=None):
@@ -277,7 +279,9 @@ class BallQuery(Function):
         torch.Tensor
             (B, npoint, nsample) tensor with the indicies of the features that form the query balls
         """
-        return _ext.ball_query(new_xyz, xyz, radius, nsample)
+        inds = _ext.ball_query(new_xyz, xyz, radius, nsample)
+        ctx.mark_non_differentiable(inds)
+        return inds
 
     @staticmethod
     def backward(ctx, a=None):


### PR DESCRIPTION
Currently the code will crash for new pytorch versions with the following error:

`RuntimeError: Expected isFloatingType(grads[i].type().scalarType()) to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)`

The pull request resolves the problem.

Reference:
https://discuss.pytorch.org/t/custom-autograd-function-with-int-tensor-input/65907