### PR TITLE
fix: unexpected list reference issue

### DIFF
--- a/scannet/load_scannet_data.py
+++ b/scannet/load_scannet_data.py
@@ -38,7 +38,7 @@ def read_aggregation(filename):
             if label in label_to_segs:
                 label_to_segs[label].extend(segs)
             else:
-                label_to_segs[label] = segs
+                label_to_segs[label] = segs.copy()
     return object_id_to_segs, label_to_segs
 
 


### PR DESCRIPTION
This is a serious bug, `label_to_segs[label].extend(segs)` unexpectedly modifies the list in `object_id_to_segs[object_id]` as `segs` are assigned to both `label_to_segs[label]` and `object_id_to_segs[object_id]` by reference. This results in some segments being assigned the wrong object id.